### PR TITLE
update the setup client

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,17 +5,11 @@
 
 from setuptools import setup, find_packages
 
-with open("README.rst") as readme_file:
+with open("README.md") as readme_file:
     readme = readme_file.read()
 
-with open("HISTORY.rst") as history_file:
-    history = history_file.read()
-
-requirements = []
-
-setup_requirements = []
-
-test_requirements = []
+with open("requirements.txt") as f:
+    requirements = f.read().splitlines()
 
 setup(
     author="HUVRdata",
@@ -32,15 +26,12 @@ setup(
     ],
     description="A python client for the HUVRdata API.",
     install_requires=requirements,
-    long_description=readme + "\n\n" + history,
+    long_description=readme,
     include_package_data=True,
     keywords="huvr_client",
     name="huvr_client",
     packages=find_packages(include=["huvr_client", "huvr_client.*"]),
-    setup_requires=setup_requirements,
     test_suite="tests",
-    tests_require=test_requirements,
     url="https://github.com/huvrdata/huvr-client",
-    version="0.2.8",
     zip_safe=False,
 )


### PR DESCRIPTION
https://github.com/huvrdata/huvr-client/actions/runs/6266363167/job/17017173651#step:4:37

```
Run python3 -m pip install --upgrade build && python3 -m build
Defaulting to user installation because normal site-packages is not writeable
Collecting build
  Downloading build-1.0.3-py3-none-any.whl (18 kB)
Collecting pyproject_hooks
  Downloading pyproject_hooks-1.0.0-py3-none-any.whl (9.3 kB)
Collecting tomli>=1.1.0
  Downloading tomli-2.0.1-py3-none-any.whl (12 kB)
Requirement already satisfied: packaging>=19.0 in /usr/local/lib/python3.10/dist-packages (from build) (23.1)
Installing collected packages: tomli, pyproject_hooks, build
Successfully installed build-1.0.3 pyproject_hooks-1.0.0 tomli-2.0.1
* Creating venv isolated environment...
* Installing packages in isolated environment... (setuptools >= [4](https://github.com/huvrdata/huvr-client/actions/runs/6266363167/job/17017173651#step:4:5)0.8.0, wheel)
* Getting build dependencies for sdist...
Traceback (most recent call last):
  File "/home/runner/.local/lib/python3.10/site-packages/pyproject_hooks/_in_process/_in_process.py", line 3[5](https://github.com/huvrdata/huvr-client/actions/runs/6266363167/job/17017173651#step:4:6)3, in <module>
    main()
  File "/home/runner/.local/lib/python3.10/site-packages/pyproject_hooks/_in_process/_in_process.py", line 335, in main
    json_out['return_val'] = hook(**hook_input['kwargs'])
  File "/home/runner/.local/lib/python3.10/site-packages/pyproject_hooks/_in_process/_in_process.py", line 28[7](https://github.com/huvrdata/huvr-client/actions/runs/6266363167/job/17017173651#step:4:8), in get_requires_for_build_sdist
    return hook(config_settings)
  File "/tmp/build-env-2h3wk[8](https://github.com/huvrdata/huvr-client/actions/runs/6266363167/job/17017173651#step:4:9)81/lib/python3.[10](https://github.com/huvrdata/huvr-client/actions/runs/6266363167/job/17017173651#step:4:11)/site-packages/setuptools/build_meta.py", line 358, in get_requires_for_build_sdist
    return self._get_build_requires(config_settings, requirements=[])
  File "/tmp/build-env-2h3wk881/lib/python3.10/site-packages/setuptools/build_meta.py", line 3[25](https://github.com/huvrdata/huvr-client/actions/runs/6266363167/job/17017173651#step:4:26), in _get_build_requires
    self.run_setup()
  File "/tmp/build-env-2h3wk881/lib/python3.10/site-packages/setuptools/build_meta.py", line 507, in run_setup
    super(_BuildMetaLegacyBackend, self).run_setup(setup_script=setup_script)
  File "/tmp/build-env-2h3wk881/lib/python3.10/site-packages/setuptools/build_meta.py", line 341, in run_setup
    exec(code, locals())
  File "<string>", line 8, in <module>
FileNotFoundError: [Errno 2] No such file or directory: 'README.rst'

ERROR Backend subprocess exited when trying to invoke get_requires_for_build_sdist
Error: Process completed with exit code 1.
```